### PR TITLE
fix: BaseEntity의 MySQL용 어노테이션 Postgre용으로 변경#21

### DIFF
--- a/src/main/java/simvex/global/common/BaseEntity.java
+++ b/src/main/java/simvex/global/common/BaseEntity.java
@@ -3,23 +3,22 @@ package simvex.global.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME(6)")
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 }


### PR DESCRIPTION
- Close #26 

---

### 🚀 작업 내용
- BaseEntity의 MySQL용 어노테이션 Postgre용으로 변경


### 📚 참고 자료, 할 말
-


### 📝 리뷰 내용 (선택)
-